### PR TITLE
fix: replace deprecated output mechanism

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -116,7 +116,7 @@ runs:
         ls -l "${binary_dir}"
         echo "::endgroup::"
 
-        echo "::set-output name=binary_dir::${binary_dir}"
+        echo "binary_dir=${binary_dir}" >> "$GITHUB_OUTPUT"
 
     - name: Add s5cmd to path
       shell: bash


### PR DESCRIPTION
Per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/, the `set-output` command has been deprecated and its replacement environment file is now supported.