### PR TITLE
chore: remove `file` dependency

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -107,7 +107,7 @@ runs:
         curl -sL -o "${archive_path}" "${asset_url}"
 
         echo "::group::Download archive"
-        file "${archive_path}"
+        ls -l "${archive_path}"
         echo "::endgroup::"
 
         tar -xf "${archive_path}" -C "${binary_dir}" s5cmd


### PR DESCRIPTION
Just a debug log, no need for `file` to be present.